### PR TITLE
On Ubuntu 18.04 do not set the LIBRARY_NAME when generating the msg interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,21 @@ file(
   GLOB srv_files
   RELATIVE ${PROJECT_SOURCE_DIR}
   srv/*.srv)
+
+find_program(LSB_RELEASE_EXEC lsb_release)
+execute_process(COMMAND ${LSB_RELEASE_EXEC} -rs
+    OUTPUT_VARIABLE LSB_RELEASE_SHORT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if (LSB_RELEASE_SHORT STREQUAL "18.04")
+  rosidl_generate_interfaces(${PROJECT_NAME}_msg_srv ${msg_files} ${srv_files}
+                            DEPENDENCIES std_msgs geometry_msgs)
+else()
 rosidl_generate_interfaces(${PROJECT_NAME}_msg_srv ${msg_files} ${srv_files}
-                           DEPENDENCIES std_msgs geometry_msgs
-                           LIBRARY_NAME ${PROJECT_NAME})
+                            DEPENDENCIES std_msgs geometry_msgs
+                            LIBRARY_NAME ${PROJECT_NAME})
+endif()
 
 # Export and install the package.
 ament_package()


### PR DESCRIPTION
This fixes a regression on Ubuntu 18.04. When compiling the setup with Ubuntu 20.04 and the corresponding ros2 distribution, we needed to add the `LIBRARY_NAME ${PROJECT_NAME}` part to find the library at runtime. It turns out this breaks the build on Ubuntu 18.04.

