### PR TITLE
Attempt to get mim_msg work with Ubuntu 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,8 @@ if (LSB_RELEASE_SHORT STREQUAL "18.04")
   rosidl_generate_interfaces(${PROJECT_NAME}_msg_srv ${msg_files} ${srv_files}
                             DEPENDENCIES std_msgs geometry_msgs)
 else()
-rosidl_generate_interfaces(${PROJECT_NAME}_msg_srv ${msg_files} ${srv_files}
-                            DEPENDENCIES std_msgs geometry_msgs
-                            LIBRARY_NAME ${PROJECT_NAME})
+  rosidl_generate_interfaces(${PROJECT_NAME} ${msg_files} ${srv_files}
+                              DEPENDENCIES std_msgs geometry_msgs)
 endif()
 
 # Export and install the package.


### PR DESCRIPTION
This is another attempt to get the mim_msg working. The problem with the current approach is that, when using the mim_msg package, there is an error like the following:

![image](https://user-images.githubusercontent.com/191719/160914355-61f05aa6-da89-4c3a-acc9-b037ae5ec840.png)

When I change the target from `${PROJECT_NAME}_msg_srv` to just `${PROJECT_NAME}`, things seem to work.

@MaximilienNaveau , do you have an idea if the `_msg_srv` suffix is needed?